### PR TITLE
Workaround for Mobile Safari 10 Problem

### DIFF
--- a/src/ShadowDOM/wrappers.js
+++ b/src/ShadowDOM/wrappers.js
@@ -218,6 +218,10 @@ window.ShadowDOMPolyfill = {};
         source.__lookupGetter__(name);
       }
       var descriptor = getDescriptor(source, name);
+      
+      // Mobile Safari 10 has "showModalDialog" in the names, but returns undefined as descriptor
+      if (descriptor === undefined) continue;
+      
       var getter, setter;
       if(typeof descriptor.value === 'function') {
           if (allowMethod) {


### PR DESCRIPTION
Mobile Safari would return a property name "showModalDialog" on the Window prototype, but when trying to get the descriptor it would return undefined.
